### PR TITLE
Adds missing go.build.import-path feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,18 @@ go:
   targets:
   - ./cmd/web-server
   - ./cmd/debug-server
-```
 
+  build:
+
+    # The go.build.flags property allows you to override the default build
+    # flags when compiling your program.
+    flags:
+    - -buildmode=default
+    - -tags=paketo
+    - -ldflags="-X main.variable=some-value"
+
+    # The go.build.import-path property allows you to specify an import path
+    # for your application. This is necessary if you are building a $GOPATH
+    # application that imports its own sub-packages.
+    import-path: example.com/some-app
+```

--- a/build_test.go
+++ b/build_test.go
@@ -66,8 +66,11 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		logs = bytes.NewBuffer(nil)
 
 		parser = &fakes.ConfigurationParser{}
-		parser.ParseCall.Returns.Targets = []string{"some-target", "other-target"}
-		parser.ParseCall.Returns.Flags = []string{"some-flag", "other-flag"}
+		parser.ParseCall.Returns.BuildConfiguration = gobuild.BuildConfiguration{
+			Targets:    []string{"some-target", "other-target"},
+			Flags:      []string{"some-flag", "other-flag"},
+			ImportPath: "some-import-path",
+		}
 
 		sourceRemover = &fakes.SourceRemover{}
 
@@ -143,6 +146,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(parser.ParseCall.Receives.Path).To(Equal(filepath.Join(workingDir, "buildpack.yml")))
 
 		Expect(pathManager.SetupCall.Receives.Workspace).To(Equal(workingDir))
+		Expect(pathManager.SetupCall.Receives.ImportPath).To(Equal("some-import-path"))
 
 		Expect(buildProcess.ExecuteCall.Receives.Config).To(Equal(gobuild.GoBuildConfiguration{
 			Workspace: "some-app-path",
@@ -343,7 +347,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when the configuration cannot be parsed", func() {
 			it.Before(func() {
-				parser.ParseCall.Returns.Err = errors.New("failed to parse configuration")
+				parser.ParseCall.Returns.Error = errors.New("failed to parse configuration")
 			})
 
 			it("returns an error", func() {

--- a/detect.go
+++ b/detect.go
@@ -8,17 +8,17 @@ import (
 
 //go:generate faux --interface ConfigurationParser --output fakes/configuration_parser.go
 type ConfigurationParser interface {
-	Parse(path string) (targets, flags []string, err error)
+	Parse(path string) (BuildConfiguration, error)
 }
 
 func Detect(parser ConfigurationParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		targets, _, err := parser.Parse(filepath.Join(context.WorkingDir, "buildpack.yml"))
+		configuration, err := parser.Parse(filepath.Join(context.WorkingDir, "buildpack.yml"))
 		if err != nil {
 			return packit.DetectResult{}, err
 		}
 
-		for _, target := range targets {
+		for _, target := range configuration.Targets {
 			files, err := filepath.Glob(filepath.Join(target, "*.go"))
 			if err != nil {
 				return packit.DetectResult{}, err

--- a/detect_test.go
+++ b/detect_test.go
@@ -33,7 +33,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(ioutil.WriteFile(filepath.Join(workingDir, "main.go"), nil, 0644)).To(Succeed())
 
 		parser = &fakes.ConfigurationParser{}
-		parser.ParseCall.Returns.Targets = []string{workingDir}
+		parser.ParseCall.Returns.BuildConfiguration.Targets = []string{workingDir}
 
 		detect = gobuild.Detect(parser)
 	})
@@ -71,7 +71,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			Expect(ioutil.WriteFile(filepath.Join(workingDir, "first", "main.go"), nil, 0644)).To(Succeed())
 			Expect(ioutil.WriteFile(filepath.Join(workingDir, "second", "main.go"), nil, 0644)).To(Succeed())
 
-			parser.ParseCall.Returns.Targets = []string{
+			parser.ParseCall.Returns.BuildConfiguration.Targets = []string{
 				filepath.Join(workingDir, "first"),
 				filepath.Join(workingDir, "second"),
 			}
@@ -113,7 +113,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("failure cases", func() {
 		context("when the configuration parser fails", func() {
 			it.Before(func() {
-				parser.ParseCall.Returns.Err = errors.New("failed to parse configuration")
+				parser.ParseCall.Returns.Error = errors.New("failed to parse configuration")
 			})
 
 			it("returns an error", func() {
@@ -126,7 +126,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		context("when file glob fails", func() {
 			it.Before(func() {
-				parser.ParseCall.Returns.Targets = []string{`\`}
+				parser.ParseCall.Returns.BuildConfiguration.Targets = []string{`\`}
 			})
 
 			it("returns an error", func() {

--- a/fakes/configuration_parser.go
+++ b/fakes/configuration_parser.go
@@ -1,6 +1,10 @@
 package fakes
 
-import "sync"
+import (
+	"sync"
+
+	gobuild "github.com/paketo-buildpacks/go-build"
+)
 
 type ConfigurationParser struct {
 	ParseCall struct {
@@ -10,15 +14,14 @@ type ConfigurationParser struct {
 			Path string
 		}
 		Returns struct {
-			Targets []string
-			Flags   []string
-			Err     error
+			BuildConfiguration gobuild.BuildConfiguration
+			Error              error
 		}
-		Stub func(string) ([]string, []string, error)
+		Stub func(string) (gobuild.BuildConfiguration, error)
 	}
 }
 
-func (f *ConfigurationParser) Parse(param1 string) ([]string, []string, error) {
+func (f *ConfigurationParser) Parse(param1 string) (gobuild.BuildConfiguration, error) {
 	f.ParseCall.Lock()
 	defer f.ParseCall.Unlock()
 	f.ParseCall.CallCount++
@@ -26,5 +29,5 @@ func (f *ConfigurationParser) Parse(param1 string) ([]string, []string, error) {
 	if f.ParseCall.Stub != nil {
 		return f.ParseCall.Stub(param1)
 	}
-	return f.ParseCall.Returns.Targets, f.ParseCall.Returns.Flags, f.ParseCall.Returns.Err
+	return f.ParseCall.Returns.BuildConfiguration, f.ParseCall.Returns.Error
 }

--- a/fakes/path_manager.go
+++ b/fakes/path_manager.go
@@ -7,14 +7,15 @@ type PathManager struct {
 		sync.Mutex
 		CallCount int
 		Receives  struct {
-			Workspace string
+			Workspace  string
+			ImportPath string
 		}
 		Returns struct {
 			GoPath string
 			Path   string
 			Err    error
 		}
-		Stub func(string) (string, string, error)
+		Stub func(string, string) (string, string, error)
 	}
 	TeardownCall struct {
 		sync.Mutex
@@ -29,13 +30,14 @@ type PathManager struct {
 	}
 }
 
-func (f *PathManager) Setup(param1 string) (string, string, error) {
+func (f *PathManager) Setup(param1 string, param2 string) (string, string, error) {
 	f.SetupCall.Lock()
 	defer f.SetupCall.Unlock()
 	f.SetupCall.CallCount++
 	f.SetupCall.Receives.Workspace = param1
+	f.SetupCall.Receives.ImportPath = param2
 	if f.SetupCall.Stub != nil {
-		return f.SetupCall.Stub(param1)
+		return f.SetupCall.Stub(param1, param2)
 	}
 	return f.SetupCall.Returns.GoPath, f.SetupCall.Returns.Path, f.SetupCall.Returns.Err
 }

--- a/go_path_manager.go
+++ b/go_path_manager.go
@@ -19,7 +19,7 @@ func NewGoPathManager(tempDir string) GoPathManager {
 	}
 }
 
-func (m GoPathManager) Setup(workspace string) (string, string, error) {
+func (m GoPathManager) Setup(workspace, importPath string) (string, string, error) {
 	_, err := os.Stat(filepath.Join(workspace, "go.mod"))
 	if err == nil {
 		return "", workspace, nil
@@ -30,7 +30,11 @@ func (m GoPathManager) Setup(workspace string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to setup GOPATH: %w", err)
 	}
 
-	appPath := filepath.Join(path, "src", "workspace")
+	if importPath == "" {
+		importPath = "workspace"
+	}
+
+	appPath := filepath.Join(path, "src", importPath)
 	err = os.MkdirAll(appPath, os.ModePerm)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to setup GOPATH: %w", err)

--- a/go_path_manager_test.go
+++ b/go_path_manager_test.go
@@ -48,14 +48,14 @@ func testGoPathManager(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("sets up the GOPATH", func() {
-			goPath, path, err := pathManager.Setup(workspacePath)
+			goPath, path, err := pathManager.Setup(workspacePath, "some/import/path")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(goPath).NotTo(BeEmpty())
 			Expect(goPath).To(HavePrefix(tempDir))
 
 			Expect(path).To(HavePrefix(goPath))
-			Expect(path).To(HaveSuffix("/src/workspace"))
+			Expect(path).To(HaveSuffix("/src/some/import/path"))
 
 			Expect(filepath.Join(path, "some-file")).To(BeARegularFile())
 		})
@@ -66,7 +66,7 @@ func testGoPathManager(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("does not setup a GOPATH", func() {
-				goPath, path, err := pathManager.Setup(workspacePath)
+				goPath, path, err := pathManager.Setup(workspacePath, "some/import/path")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(path).To(Equal(workspacePath))
 
@@ -85,7 +85,7 @@ func testGoPathManager(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					_, _, err := pathManager.Setup(workspacePath)
+					_, _, err := pathManager.Setup(workspacePath, "some/import/path")
 					Expect(err).To(MatchError(ContainSubstring("failed to setup GOPATH:")))
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
 				})
@@ -97,7 +97,7 @@ func testGoPathManager(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					_, _, err := pathManager.Setup(workspacePath)
+					_, _, err := pathManager.Setup(workspacePath, "some/import/path")
 					Expect(err).To(MatchError(ContainSubstring("failed to copy application source onto GOPATH:")))
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
 				})

--- a/integration/import_path_test.go
+++ b/integration/import_path_test.go
@@ -1,0 +1,95 @@
+package integration_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testImportPath(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+	})
+
+	context("when building a simple app with sub-packages", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds successfully", func() {
+			var err error
+			source, err = occam.Source(filepath.Join("testdata", "import_path"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.Build.
+				WithNoPull().
+				WithBuildpacks(
+					settings.Buildpacks.GoDist.Online,
+					settings.Buildpacks.GoBuild.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			container, err = docker.Container.Run.Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+
+			response, err := http.Get(fmt.Sprintf("http://localhost:%s", container.HostPort()))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			content, err := ioutil.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("go1.14"))
+			Expect(string(content)).To(ContainSubstring("/workspace contents: []"))
+
+			Expect(logs).To(ContainLines(
+				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
+				"  Executing build process",
+				fmt.Sprintf("    Running 'go build -o /layers/%s/targets/bin -buildmode pie .'", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+				"",
+				"  Assigning launch processes",
+				fmt.Sprintf("    web: /layers/%s/targets/bin/import_path", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+			))
+		})
+	})
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -82,6 +82,7 @@ func TestIntegration(t *testing.T) {
 	suite("BuildFailure", testBuildFailure)
 	suite("BuildFlags", testBuildFlags)
 	suite("Default", testDefault)
+	suite("ImportPath", testImportPath)
 	suite("LayerReuse", testLayerReuse)
 	suite("Mod", testMod)
 	suite("Targets", testTargets)

--- a/integration/testdata/import_path/buildpack.yml
+++ b/integration/testdata/import_path/buildpack.yml
@@ -1,0 +1,4 @@
+---
+go:
+  build:
+    import-path: github.com/paketo-buildpacks/go-build/integration/testdata/import_path

--- a/integration/testdata/import_path/handlers/details.go
+++ b/integration/testdata/import_path/handlers/details.go
@@ -1,0 +1,15 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
+)
+
+func Details(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, runtime.Version())
+
+	paths, _ := filepath.Glob("/workspace/*")
+	fmt.Fprintf(w, "/workspace contents: %v\n", paths)
+}

--- a/integration/testdata/import_path/main.go
+++ b/integration/testdata/import_path/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/paketo-buildpacks/go-build/integration/testdata/import_path/handlers"
+)
+
+func main() {
+	http.HandleFunc("/", handlers.Details)
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil))
+}


### PR DESCRIPTION
When an app is a $GOPATH app, but also includes internal sub-packages, the `go build` command will need to be run with the app source code located in a property rooted $GOPATH. This means that we will need to know what the "import path" is for the application so that we can reconstruct this path during build time. The field only applies to the build process and so has been nested under the go.build property set.