### PR TITLE
Have the build phase reparse the BuildConfigurationFrom the environment.

### DIFF
--- a/build.go
+++ b/build.go
@@ -113,7 +113,6 @@ func Build(
 		logs.Subprocess("web: %s", command)
 
 		return packit.BuildResult{
-			Plan:   context.Plan,
 			Layers: []packit.Layer{targetsLayer, goCacheLayer},
 			Launch: packit.LaunchMetadata{
 				Processes: []packit.Process{

--- a/build_test.go
+++ b/build_test.go
@@ -32,6 +32,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		logs          *bytes.Buffer
 		timestamp     time.Time
 		sourceRemover *fakes.SourceRemover
+		parser        *fakes.ConfigurationParser
 
 		build packit.BuildFunc
 	)
@@ -66,7 +67,15 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		sourceRemover = &fakes.SourceRemover{}
 
+		parser = &fakes.ConfigurationParser{}
+		parser.ParseCall.Returns.BuildConfiguration = gobuild.BuildConfiguration{
+			Targets:    []string{"some-target", "other-target"},
+			Flags:      []string{"some-flag", "other-flag"},
+			ImportPath: "some-import-path",
+		}
+
 		build = gobuild.Build(
+			parser,
 			buildProcess,
 			pathManager,
 			clock,

--- a/build_test.go
+++ b/build_test.go
@@ -101,34 +101,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Version: "some-version",
 			},
 			Layers: packit.Layers{Path: layersDir},
-			Plan: packit.BuildpackPlan{
-				Entries: []packit.BuildpackPlanEntry{
-					{
-						Name: "go-build",
-						Metadata: map[string]interface{}{
-							"targets":     []interface{}{"some-target", "other-target"},
-							"flags":       []interface{}{"some-flag", "other-flag"},
-							"import-path": "some-import-path",
-						},
-					},
-				},
-			},
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(result).To(Equal(packit.BuildResult{
-			Plan: packit.BuildpackPlan{
-				Entries: []packit.BuildpackPlanEntry{
-					{
-						Name: "go-build",
-						Metadata: map[string]interface{}{
-							"targets":     []interface{}{"some-target", "other-target"},
-							"flags":       []interface{}{"some-flag", "other-flag"},
-							"import-path": "some-import-path",
-						},
-					},
-				},
-			},
 			Layers: []packit.Layer{
 				{
 					Name:      "targets",
@@ -206,30 +182,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Version: "some-version",
 				},
 				Layers: packit.Layers{Path: layersDir},
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{
-						{
-							Name: "go-build",
-							Metadata: map[string]interface{}{
-								"targets": []interface{}{"some-target", "other-target"},
-							},
-						},
-					},
-				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{
-						{
-							Name: "go-build",
-							Metadata: map[string]interface{}{
-								"targets": []interface{}{"some-target", "other-target"},
-							},
-						},
-					},
-				},
 				Layers: []packit.Layer{
 					{
 						Name:      "targets",
@@ -288,30 +244,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Version: "some-version",
 				},
 				Layers: packit.Layers{Path: layersDir},
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{
-						{
-							Name: "go-build",
-							Metadata: map[string]interface{}{
-								"targets": []interface{}{"some-target", "other-target"},
-							},
-						},
-					},
-				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result).To(Equal(packit.BuildResult{
-				Plan: packit.BuildpackPlan{
-					Entries: []packit.BuildpackPlanEntry{
-						{
-							Name: "go-build",
-							Metadata: map[string]interface{}{
-								"targets": []interface{}{"some-target", "other-target"},
-							},
-						},
-					},
-				},
 				Layers: []packit.Layer{
 					{
 						Name:      "targets",
@@ -368,16 +304,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError(ContainSubstring("failed to parse layer content metadata")))
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
@@ -399,16 +325,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError(ContainSubstring("failed to parse layer content metadata")))
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
@@ -430,16 +346,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to checksum working dir"))
 			})
@@ -460,16 +366,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to setup go path"))
 			})
@@ -490,16 +386,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to execute build process"))
 			})
@@ -520,16 +406,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to teardown go path"))
 			})
@@ -551,16 +427,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to identify start command from reused layer metadata"))
 			})
@@ -581,16 +447,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Version: "some-version",
 					},
 					Layers: packit.Layers{Path: layersDir},
-					Plan: packit.BuildpackPlan{
-						Entries: []packit.BuildpackPlanEntry{
-							{
-								Name: "go-build",
-								Metadata: map[string]interface{}{
-									"targets": []interface{}{"some-target", "other-target"},
-								},
-							},
-						},
-					},
 				})
 				Expect(err).To(MatchError("failed to remove source"))
 			})

--- a/detect.go
+++ b/detect.go
@@ -11,38 +11,18 @@ type ConfigurationParser interface {
 
 func Detect(parser ConfigurationParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		configuration, err := parser.Parse(context.WorkingDir)
-		if err != nil {
+		if _, err := parser.Parse(context.WorkingDir); err != nil {
 			return packit.DetectResult{}, packit.Fail.WithMessage("failed to parse build configuration: %w", err)
-		}
-
-		metadata := map[string]interface{}{
-			"targets": configuration.Targets,
-		}
-
-		if flags := configuration.Flags; flags != nil {
-			metadata["flags"] = flags
-		}
-
-		if importPath := configuration.ImportPath; importPath != "" {
-			metadata["import-path"] = importPath
 		}
 
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{{Name: "go-build"}},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "go",
-						Metadata: map[string]interface{}{
-							"build": true,
-						},
+				Requires: []packit.BuildPlanRequirement{{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"build": true,
 					},
-					{
-						Name:     "go-build",
-						Metadata: metadata,
-					},
-				},
+				}},
 			},
 		}, nil
 	}

--- a/detect_test.go
+++ b/detect_test.go
@@ -38,21 +38,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Plan).To(Equal(packit.BuildPlan{
-			Provides: []packit.BuildPlanProvision{{Name: "go-build"}},
-			Requires: []packit.BuildPlanRequirement{
-				{
-					Name: "go",
-					Metadata: map[string]interface{}{
-						"build": true,
-					},
+			Requires: []packit.BuildPlanRequirement{{
+				Name: "go",
+				Metadata: map[string]interface{}{
+					"build": true,
 				},
-				{
-					Name: "go-build",
-					Metadata: map[string]interface{}{
-						"targets": []string{workingDir},
-					},
-				},
-			},
+			}},
 		}))
 
 		Expect(parser.ParseCall.Receives.WorkingDir).To(Equal(workingDir))
@@ -69,22 +60,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{{Name: "go-build"}},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "go",
-						Metadata: map[string]interface{}{
-							"build": true,
-						},
+				Requires: []packit.BuildPlanRequirement{{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"build": true,
 					},
-					{
-						Name: "go-build",
-						Metadata: map[string]interface{}{
-							"targets": []string{workingDir},
-							"flags":   []string{"-some-flag=flag"},
-						},
-					},
-				},
+				}},
 			}))
 
 			Expect(parser.ParseCall.Receives.WorkingDir).To(Equal(workingDir))
@@ -102,22 +83,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{{Name: "go-build"}},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "go",
-						Metadata: map[string]interface{}{
-							"build": true,
-						},
+				Requires: []packit.BuildPlanRequirement{{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"build": true,
 					},
-					{
-						Name: "go-build",
-						Metadata: map[string]interface{}{
-							"targets":     []string{workingDir},
-							"import-path": "./some/path",
-						},
-					},
-				},
+				}},
 			}))
 
 			Expect(parser.ParseCall.Receives.WorkingDir).To(Equal(workingDir))
@@ -138,24 +109,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Plan).To(Equal(packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{{Name: "go-build"}},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: "go",
-						Metadata: map[string]interface{}{
-							"build": true,
-						},
+				Requires: []packit.BuildPlanRequirement{{
+					Name: "go",
+					Metadata: map[string]interface{}{
+						"build": true,
 					},
-					{
-						Name: "go-build",
-						Metadata: map[string]interface{}{
-							"targets": []string{
-								filepath.Join(workingDir, "first"),
-								filepath.Join(workingDir, "second"),
-							},
-						},
-					},
-				},
+				}},
 			}))
 
 			Expect(parser.ParseCall.Receives.WorkingDir).To(Equal(workingDir))

--- a/run/main.go
+++ b/run/main.go
@@ -19,6 +19,7 @@ func main() {
 			configParser,
 		),
 		gobuild.Build(
+			configParser,
 			gobuild.NewGoBuildProcess(
 				pexec.NewExecutable("go"),
 				logEmitter,


### PR DESCRIPTION
* A short explanation of the proposed change:

Rebuild the BuildConfiguration from the environment to allow build phases prior to go-build in the order to influence the way go-build executes.  A canonical example of this would be a function framework injecting a `package main` entrypoint around a function that should be invoked when requests are received.

Fixes: https://github.com/paketo-buildpacks/go-build/issues/91

* An explanation of the use cases your change enables:

This allows downstream buildpacks to synthesize an entrypoint during their build phase and direct go-build to build that target by setting `BP_GO_TARGETS`.

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
