### PR TITLE
Adds a process entry for all of the binaries

### DIFF
--- a/fakes/build_process.go
+++ b/fakes/build_process.go
@@ -14,14 +14,14 @@ type BuildProcess struct {
 			Config gobuild.GoBuildConfiguration
 		}
 		Returns struct {
-			Command string
-			Err     error
+			Binaries []string
+			Err      error
 		}
-		Stub func(gobuild.GoBuildConfiguration) (string, error)
+		Stub func(gobuild.GoBuildConfiguration) ([]string, error)
 	}
 }
 
-func (f *BuildProcess) Execute(param1 gobuild.GoBuildConfiguration) (string, error) {
+func (f *BuildProcess) Execute(param1 gobuild.GoBuildConfiguration) ([]string, error) {
 	f.ExecuteCall.Lock()
 	defer f.ExecuteCall.Unlock()
 	f.ExecuteCall.CallCount++
@@ -29,5 +29,5 @@ func (f *BuildProcess) Execute(param1 gobuild.GoBuildConfiguration) (string, err
 	if f.ExecuteCall.Stub != nil {
 		return f.ExecuteCall.Stub(param1)
 	}
-	return f.ExecuteCall.Returns.Command, f.ExecuteCall.Returns.Err
+	return f.ExecuteCall.Returns.Binaries, f.ExecuteCall.Returns.Err
 }

--- a/go_build_process_test.go
+++ b/go_build_process_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/paketo-buildpacks/go-build/fakes"
 	"github.com/paketo-buildpacks/packit/chronos"
 	"github.com/paketo-buildpacks/packit/pexec"
-	"github.com/paketo-buildpacks/packit/scribe"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -82,7 +81,7 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 			return t
 		})
 
-		buildProcess = gobuild.NewGoBuildProcess(executable, scribe.NewEmitter(logs), clock)
+		buildProcess = gobuild.NewGoBuildProcess(executable, gobuild.NewLogEmitter(logs), clock)
 	})
 
 	it.After(func() {
@@ -93,7 +92,7 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("executes the go build process", func() {
-		command, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
+		binaries, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
 			Workspace: workspacePath,
 			Output:    filepath.Join(layerPath, "bin"),
 			GoPath:    goPath,
@@ -101,7 +100,11 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 			Targets:   []string{"./some-target", "./other-target"},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(command).To(Equal(filepath.Join(layerPath, "bin", "a_command")))
+		Expect(binaries).To(Equal([]string{
+			filepath.Join(layerPath, "bin", "a_command"),
+			filepath.Join(layerPath, "bin", "b_command"),
+			filepath.Join(layerPath, "bin", "c_command"),
+		}))
 
 		Expect(filepath.Join(layerPath, "bin")).To(BeADirectory())
 
@@ -127,7 +130,7 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("executes the go build process with those flags", func() {
-			command, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
+			binaries, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
 				Workspace: workspacePath,
 				Output:    filepath.Join(layerPath, "bin"),
 				GoCache:   goCache,
@@ -135,7 +138,11 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				Flags:     []string{"-buildmode", "default", "-ldflags", "-X main.variable=some-value", "-mod", "mod"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(command).To(Equal(filepath.Join(layerPath, "bin", "a_command")))
+			Expect(binaries).To(Equal([]string{
+				filepath.Join(layerPath, "bin", "a_command"),
+				filepath.Join(layerPath, "bin", "b_command"),
+				filepath.Join(layerPath, "bin", "c_command"),
+			}))
 
 			Expect(filepath.Join(layerPath, "bin")).To(BeADirectory())
 
@@ -163,7 +170,7 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("executes the go build process without setting GOPATH", func() {
-			command, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
+			binaries, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
 				Workspace: workspacePath,
 				Output:    filepath.Join(layerPath, "bin"),
 				GoPath:    "",
@@ -171,7 +178,11 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				Targets:   []string{"./some-target", "./other-target"},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(command).To(Equal(filepath.Join(layerPath, "bin", "a_command")))
+			Expect(binaries).To(Equal([]string{
+				filepath.Join(layerPath, "bin", "a_command"),
+				filepath.Join(layerPath, "bin", "b_command"),
+				filepath.Join(layerPath, "bin", "c_command"),
+			}))
 
 			Expect(filepath.Join(layerPath, "bin")).To(BeADirectory())
 

--- a/go_buildpack_yml_parser.go
+++ b/go_buildpack_yml_parser.go
@@ -6,17 +6,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/buildkite/interpolate"
-	"github.com/paketo-buildpacks/packit/scribe"
-	"gopkg.in/yaml.v2"
 	"github.com/Masterminds/semver"
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v2"
 )
 
 type GoBuildpackYMLParser struct {
-	logger scribe.Emitter
+	logger LogEmitter
 }
 
-func NewGoBuildpackYMLParser(logger scribe.Emitter) GoBuildpackYMLParser {
+func NewGoBuildpackYMLParser(logger LogEmitter) GoBuildpackYMLParser {
 	return GoBuildpackYMLParser{
 		logger: logger,
 	}

--- a/go_buildpack_yml_parser_test.go
+++ b/go_buildpack_yml_parser_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	gobuild "github.com/paketo-buildpacks/go-build"
-	"github.com/paketo-buildpacks/packit/scribe"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -43,7 +42,7 @@ go:
 `), 0644)).To(Succeed())
 
 		logs = bytes.NewBuffer(nil)
-		goBuildpackYMLParser = gobuild.NewGoBuildpackYMLParser(scribe.NewEmitter(logs))
+		goBuildpackYMLParser = gobuild.NewGoBuildpackYMLParser(gobuild.NewLogEmitter(logs))
 	})
 
 	it.After(func() {

--- a/log_emitter.go
+++ b/log_emitter.go
@@ -1,0 +1,24 @@
+package gobuild
+
+import (
+	"io"
+
+	"github.com/paketo-buildpacks/packit"
+	"github.com/paketo-buildpacks/packit/scribe"
+)
+
+type LogEmitter struct {
+	scribe.Emitter
+}
+
+func NewLogEmitter(output io.Writer) LogEmitter {
+	return LogEmitter{
+		Emitter: scribe.NewEmitter(output),
+	}
+}
+
+func (l LogEmitter) ListProcesses(processes []packit.Process) {
+	for _, p := range processes {
+		l.Subprocess("%s: %s", p.Type, p.Command)
+	}
+}

--- a/run/main.go
+++ b/run/main.go
@@ -7,11 +7,10 @@ import (
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/chronos"
 	"github.com/paketo-buildpacks/packit/pexec"
-	"github.com/paketo-buildpacks/packit/scribe"
 )
 
 func main() {
-	logEmitter := scribe.NewEmitter(os.Stdout)
+	logEmitter := gobuild.NewLogEmitter(os.Stdout)
 	configParser := gobuild.NewBuildConfigurationParser(gobuild.NewGoTargetManager(), gobuild.NewGoBuildpackYMLParser(logEmitter))
 
 	packit.Run(


### PR DESCRIPTION
- Every binary that is produced as part of the build process is now
added to the process list with their type being their base binary name.

Resolves #139

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
