### PR TITLE
Keep old modules behavior for 1.16

### DIFF
--- a/go_build_process.go
+++ b/go_build_process.go
@@ -63,6 +63,7 @@ func (p GoBuildProcess) Execute(config GoBuildConfiguration) ([]string, error) {
 	if config.GoPath != "" {
 		env = append(env, fmt.Sprintf("GOPATH=%s", config.GoPath))
 	}
+	env = append(env, "GO111MODULE=auto")
 
 	printedArgs := []string{"go"}
 	for _, arg := range args {

--- a/go_build_process_test.go
+++ b/go_build_process_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
 func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
@@ -124,6 +125,7 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 		Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal(workspacePath))
 		Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("GOPATH=%s", goPath)))
 		Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("GOCACHE=%s", goCache)))
+		Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement("GO111MODULE=auto"))
 
 		Expect(logs.String()).To(ContainSubstring("  Executing build process"))
 		Expect(logs.String()).To(ContainSubstring(fmt.Sprintf("    Running 'go build -o %s -buildmode pie ./some-target ./other-target'", filepath.Join(layerPath, "bin"))))
@@ -169,9 +171,11 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 			Expect(executable.ExecuteCall.Receives.Execution.Dir).To(Equal(workspacePath))
 			Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("GOCACHE=%s", goCache)))
 
-			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
-			Expect(logs.String()).To(ContainSubstring(fmt.Sprintf(`    Running 'go build -o %s -buildmode default -ldflags "-X main.variable=some-value" -mod mod .'`, filepath.Join(layerPath, "bin"))))
-			Expect(logs.String()).To(ContainSubstring("      Completed in 1s"))
+			Expect(logs).To(ContainLines(
+				"  Executing build process",
+				fmt.Sprintf(`    Running 'go build -o %s -buildmode default -ldflags "-X main.variable=some-value" -mod mod .'`, filepath.Join(layerPath, "bin")),
+				"      Completed in 1s",
+			))
 		})
 	})
 
@@ -240,9 +244,11 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 				Expect(err).To(MatchError("failed to execute 'go build': command failed"))
 
-				Expect(logs.String()).To(ContainSubstring("      Failed after 1s"))
-				Expect(logs.String()).To(ContainSubstring("        build error stdout"))
-				Expect(logs.String()).To(ContainSubstring("        build error stderr"))
+				Expect(logs).To(ContainLines(
+					"      Failed after 1s",
+					"        build error stdout",
+					"        build error stderr",
+				))
 			})
 		})
 
@@ -269,8 +275,10 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 				Expect(err).To(MatchError("failed to execute 'go list': command failed"))
 
-				Expect(logs.String()).To(ContainSubstring("        build error stdout"))
-				Expect(logs.String()).To(ContainSubstring("        build error stderr"))
+				Expect(logs).To(ContainLines(
+					"        build error stdout",
+					"        build error stderr",
+				))
 			})
 		})
 

--- a/integration/build_flags_test.go
+++ b/integration/build_flags_test.go
@@ -75,7 +75,7 @@ func testBuildFlags(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring(`variable value: "some-value"`),
 						ContainSubstring("/workspace contents: []"),
 					),
@@ -125,7 +125,7 @@ func testBuildFlags(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring(`variable value: "env-value"`),
 						ContainSubstring("/workspace contents: []"),
 					),

--- a/integration/buildpack_yml_test.go
+++ b/integration/buildpack_yml_test.go
@@ -80,7 +80,7 @@ go:
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("first: go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("first: go1.16")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
@@ -117,7 +117,7 @@ go:
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(Serve(ContainSubstring("third: go1.15")).OnPort(8080))
+				Eventually(container).Should(Serve(ContainSubstring("third: go1.16")).OnPort(8080))
 
 				Expect(logs).To(ContainLines(
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -75,7 +75,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring("/workspace contents: []"),
 					),
 				).OnPort(8080),
@@ -138,7 +138,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 		})
 	})
 
@@ -189,7 +189,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring("/workspace contents: []"),
 					),
 				).OnPort(8080),

--- a/integration/import_path_test.go
+++ b/integration/import_path_test.go
@@ -76,7 +76,7 @@ func testImportPath(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring("/workspace contents: []"),
 					),
 				).OnPort(8080),

--- a/integration/keep_files_test.go
+++ b/integration/keep_files_test.go
@@ -75,7 +75,7 @@ func testKeepFiles(t *testing.T, context spec.G, it spec.S) {
 			Eventually(container).Should(
 				Serve(
 					SatisfyAll(
-						ContainSubstring("go1.15"),
+						ContainSubstring("go1.16"),
 						ContainSubstring("/workspace contents: [/workspace/assets /workspace/static-file]"),
 						ContainSubstring("file contents: Hello world!"),
 					),

--- a/integration/mod_test.go
+++ b/integration/mod_test.go
@@ -72,7 +72,7 @@ func testMod(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),

--- a/integration/targets_test.go
+++ b/integration/targets_test.go
@@ -73,7 +73,7 @@ func testTargets(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("first: go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("first: go1.16")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
@@ -109,7 +109,7 @@ func testTargets(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("second: go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("second: go1.16")).OnPort(8080))
 
 		})
 	})

--- a/integration/vendor_test.go
+++ b/integration/vendor_test.go
@@ -72,7 +72,7 @@ func testVendor(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
@@ -131,7 +131,7 @@ func testVendor(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("go1.15")).OnPort(8080))
+			Eventually(container).Should(Serve(ContainSubstring("go1.16")).OnPort(8080))
 		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In Go 1.16, the default behavior for how `go build` handles modules has changed. It will now assume that all code is using modules. Since this is not necessarily true for apps using our buildpack, we should set the `GO111MODULE` environment variable to `auto` as this will restore the old behavior where it will switch based on the presence of a `go.mod` file. Check out https://blog.golang.org/go116-module-changes for more details.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
