### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -118,6 +118,7 @@ func Build(
 				Type:    "web",
 				Command: binaries[0],
 				Direct:  context.Stack == TinyStackName,
+				Default: true,
 			},
 		}
 
@@ -127,6 +128,7 @@ func Build(
 					Type:    "web",
 					Command: fmt.Sprintf("watchexec --restart --watch %s --watch %s '%s'", context.WorkingDir, filepath.Dir(binaries[0]), binaries[0]),
 					Direct:  context.Stack == TinyStackName,
+					Default: true,
 				},
 			}
 		}

--- a/build_test.go
+++ b/build_test.go
@@ -141,6 +141,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Type:    "web",
 						Command: "path/some-start-command",
 						Direct:  false,
+						Default: true,
 					},
 					{
 						Type:    "some-start-command",
@@ -209,6 +210,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						Type:    "web",
 						Command: fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/some-start-command'", workingDir),
 						Direct:  false,
+						Default: true,
 					},
 					{
 						Type:    "some-start-command",
@@ -284,6 +286,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 							Type:    "web",
 							Command: "path/some-start-command",
 							Direct:  true,
+							Default: true,
 						},
 						{
 							Type:    "some-start-command",
@@ -361,6 +364,7 @@ launch = true
 							Type:    "web",
 							Command: "path/some-start-command",
 							Direct:  false,
+							Default: true,
 						},
 						{
 							Type:    "some-start-command",

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/go-build"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
