### PR TITLE
Use direct=true processes for go buildpack

### DIFF
--- a/build.go
+++ b/build.go
@@ -3,6 +3,7 @@ package gobuild
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/paketo-buildpacks/packit"
@@ -125,8 +126,8 @@ func Build(
 			if shouldReload {
 				processes = append(processes, packit.Process{
 					Type:    fmt.Sprintf("reload-%s", filepath.Base(binary)),
-					Command: "/bin/bash",
-					Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch %s '%s'", context.WorkingDir, filepath.Dir(binary), binary)},
+					Command: "watchexec",
+					Args:    []string{"--restart", "--watch", context.WorkingDir, "--watch", filepath.Dir(binary), strconv.Quote(binary)},
 					Direct:  true,
 					Default: index == 0,
 				})

--- a/build.go
+++ b/build.go
@@ -125,7 +125,8 @@ func Build(
 			if shouldReload {
 				processes = append(processes, packit.Process{
 					Type:    fmt.Sprintf("reload-%s", filepath.Base(binary)),
-					Command: fmt.Sprintf("watchexec --restart --watch %s --watch %s '%s'", context.WorkingDir, filepath.Dir(binary), binary),
+					Command: "/bin/bash",
+					Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch %s '%s'", context.WorkingDir, filepath.Dir(binary), binary)},
 					Direct:  true,
 					Default: index == 0,
 				})

--- a/build.go
+++ b/build.go
@@ -118,7 +118,7 @@ func Build(
 			processes = append(processes, packit.Process{
 				Type:    filepath.Base(binary),
 				Command: binary,
-				Direct:  context.Stack == TinyStackName,
+				Direct:  true,
 				Default: index == 0 && !shouldReload,
 			})
 
@@ -126,7 +126,7 @@ func Build(
 				processes = append(processes, packit.Process{
 					Type:    fmt.Sprintf("reload-%s", filepath.Base(binary)),
 					Command: fmt.Sprintf("watchexec --restart --watch %s --watch %s '%s'", context.WorkingDir, filepath.Dir(binary), binary),
-					Direct:  context.Stack == TinyStackName,
+					Direct:  true,
 					Default: index == 0,
 				})
 			}

--- a/build_test.go
+++ b/build_test.go
@@ -207,8 +207,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					{
 						Type:    "reload-some-start-command",
-						Command: "/bin/bash",
-						Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/some-start-command'", workingDir)},
+						Command: "watchexec",
+						Args:    []string{"--restart", "--watch", workingDir, "--watch", "path", "\"path/some-start-command\""},
 						Direct:  true,
 						Default: true,
 					},
@@ -219,8 +219,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					{
 						Type:    "reload-another-start-command",
-						Command: "/bin/bash",
-						Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/another-start-command'", workingDir)},
+						Command: "watchexec",
+						Args:    []string{"--restart", "--watch", workingDir, "--watch", "path", "\"path/another-start-command\""},
 						Direct:  true,
 					},
 				},

--- a/build_test.go
+++ b/build_test.go
@@ -140,13 +140,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "some-start-command",
 						Command: "path/some-start-command",
-						Direct:  false,
+						Direct:  true,
 						Default: true,
 					},
 					{
 						Type:    "another-start-command",
 						Command: "path/another-start-command",
-						Direct:  false,
+						Direct:  true,
 					},
 				},
 			},
@@ -203,23 +203,23 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "some-start-command",
 						Command: "path/some-start-command",
-						Direct:  false,
+						Direct:  true,
 					},
 					{
 						Type:    "reload-some-start-command",
 						Command: fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/some-start-command'", workingDir),
-						Direct:  false,
+						Direct:  true,
 						Default: true,
 					},
 					{
 						Type:    "another-start-command",
 						Command: "path/another-start-command",
-						Direct:  false,
+						Direct:  true,
 					},
 					{
 						Type:    "reload-another-start-command",
 						Command: fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/another-start-command'", workingDir),
-						Direct:  false,
+						Direct:  true,
 					},
 				},
 			}))
@@ -347,13 +347,13 @@ launch = true
 						{
 							Type:    "some-start-command",
 							Command: "path/some-start-command",
-							Direct:  false,
+							Direct:  true,
 							Default: true,
 						},
 						{
 							Type:    "another-start-command",
 							Command: "path/another-start-command",
-							Direct:  false,
+							Direct:  true,
 						},
 					},
 				},

--- a/build_test.go
+++ b/build_test.go
@@ -207,7 +207,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					{
 						Type:    "reload-some-start-command",
-						Command: fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/some-start-command'", workingDir),
+						Command: "/bin/bash",
+						Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/some-start-command'", workingDir)},
 						Direct:  true,
 						Default: true,
 					},
@@ -218,7 +219,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					},
 					{
 						Type:    "reload-another-start-command",
-						Command: fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/another-start-command'", workingDir),
+						Command: "/bin/bash",
+						Args:    []string{"-c", fmt.Sprintf("watchexec --restart --watch %s --watch path 'path/another-start-command'", workingDir)},
 						Direct:  true,
 					},
 				},

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -258,11 +258,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
 				"  Assigning launch processes:",
-				fmt.Sprintf("    workspace:                  /layers/%s/targets/bin/workspace",
-					strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
-				fmt.Sprintf("    reload-workspace (default): watchexec --restart --watch /workspace --watch /layers/%s/targets/bin '/layers/%s/targets/bin/workspace'",
-					strings.ReplaceAll(settings.Buildpack.ID, "/", "_"),
-					strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				fmt.Sprintf("    workspace:                  /layers/%s/targets/bin/workspace", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				fmt.Sprintf("    reload-workspace (default): watchexec --restart --watch /workspace --watch /layers/%[1]s/targets/bin \"/layers/%[1]s/targets/bin/workspace\"", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 			))
 
 			noReloadContainer, err = docker.Container.Run.


### PR DESCRIPTION
The go buildpack currently uses direct=false processes. AFAICT,
the buildpack itself, doesn't need to support direct=false process types
as it does not rely on any profile.d scripts or use any environment
variables as arguments for its process type. Direct=false processes
also have an extremely unintuitive/error causing behavior with arg
handling at runtime. For more info see
https://github.com/buildpacks/rfcs/blob/main/text/0093-remove-shell-processes.md#argument-handling

This also prevents divergence in the behavior of the output images
between the tiny stack and the other stacks with runtime arguments being
handled consistently now.

This also leads to performance improvements as direct=true processes
do not need to load bash/go through the shell for startup.

Related RFC https://github.com/paketo-buildpacks/rfcs/pull/136

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
