### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.7"
   description = "A buildpack for compiling Go applications and writing start commands"
   homepage = "https://github.com/paketo-buildpacks/go-build"
   id = "paketo-buildpacks/go-build"
-  name = "Paketo Go Build Buildpack"
+  name = "Paketo Buildpack for Go Build"
   keywords = ["go", "build", "compilation", "binary"]
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 


### PR DESCRIPTION
Renames 'Paketo Go Build Buildpack' to 'Paketo Buildpack for Go Build'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
