### PR TITLE
Static stack support

### DIFF
--- a/go_build_process.go
+++ b/go_build_process.go
@@ -23,12 +23,13 @@ type Executable interface {
 }
 
 type GoBuildConfiguration struct {
-	Workspace string
-	Output    string
-	GoPath    string
-	GoCache   string
-	Targets   []string
-	Flags     []string
+	Workspace  string
+	Output     string
+	GoPath     string
+	GoCache    string
+	Targets    []string
+	Flags      []string
+	DisableCGO bool
 }
 
 type GoBuildProcess struct {
@@ -69,6 +70,10 @@ func (p GoBuildProcess) Execute(config GoBuildConfiguration) ([]string, error) {
 		env = append(env, fmt.Sprintf("GOPATH=%s", config.GoPath))
 	}
 	env = append(env, "GO111MODULE=auto")
+
+	if config.DisableCGO {
+		env = append(env, "CGO_ENABLED=0")
+	}
 
 	printedArgs := []string{"go"}
 	for _, arg := range args {

--- a/go_build_process_test.go
+++ b/go_build_process_test.go
@@ -133,6 +133,24 @@ func testGoBuildProcess(t *testing.T, context spec.G, it spec.S) {
 		Expect(logs.String()).To(ContainSubstring("      Completed in 1s"))
 	})
 
+	it("propagates the disable cgo flag", func() {
+		binaries, err := buildProcess.Execute(gobuild.GoBuildConfiguration{
+			Workspace:  workspacePath,
+			Output:     filepath.Join(layerPath, "bin"),
+			GoPath:     goPath,
+			GoCache:    goCache,
+			Targets:    []string{"./some-target"},
+			DisableCGO: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(binaries).To(Equal([]string{
+			filepath.Join(layerPath, "bin", "some-target"),
+		}))
+
+		Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement("CGO_ENABLED=0"))
+	})
+
 	context("when there are build flags", func() {
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(workspacePath, "go.mod"), nil, 0644)).To(Succeed())

--- a/integration.json
+++ b/integration.json
@@ -1,8 +1,6 @@
 {
   "go-dist": "github.com/paketo-buildpacks/go-dist",
   "watchexec": "github.com/paketo-buildpacks/watchexec",
-  "tiny-builder": "paketobuildpacks/builder-jammy-buildpackless-tiny",
-  "tiny-run-image": "index.docker.io/paketobuildpacks/run-jammy-tiny",
   "builders": [
     "paketobuildpacks/builder-jammy-buildpackless-static",
     "paketobuildpacks/builder-jammy-buildpackless-tiny",

--- a/integration.json
+++ b/integration.json
@@ -2,5 +2,11 @@
   "go-dist": "github.com/paketo-buildpacks/go-dist",
   "watchexec": "github.com/paketo-buildpacks/watchexec",
   "tiny-builder": "paketobuildpacks/builder-jammy-buildpackless-tiny",
-  "tiny-run-image": "index.docker.io/paketobuildpacks/run-jammy-tiny"
+  "tiny-run-image": "index.docker.io/paketobuildpacks/run-jammy-tiny",
+  "builders": [
+    "paketobuildpacks/builder-jammy-buildpackless-static",
+    "paketobuildpacks/builder-jammy-buildpackless-tiny",
+    "paketobuildpacks/builder-jammy-buildpackless-base",
+    "paketobuildpacks/builder-jammy-buildpackless-full"
+  ]
 }

--- a/integration/build_failure_test.go
+++ b/integration/build_failure_test.go
@@ -69,7 +69,7 @@ func testBuildFailure(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Executing build process",
-				fmt.Sprintf("    Running 'go build -o /layers/%s/targets/bin -buildmode pie -trimpath .'", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				MatchRegexp(fmt.Sprintf(`Running 'go build -o /layers/%s/targets/bin -buildmode ([^\s]+) -trimpath .'`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Failed after ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -255,7 +255,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		it("builds successfully and makes reloadable and non-reloadable process types available with the tiny builder", func() {
+		it("builds successfully and makes reloadable and non-reloadable process types available", func() {
 			var (
 				err  error
 				logs fmt.Stringer
@@ -270,7 +270,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.GoDist.Online,
 					settings.Buildpacks.GoBuild.Online,
 				).
-				WithBuilder("paketobuildpacks/builder-jammy-buildpackless-tiny").
 				WithEnv(map[string]string{
 					"BP_LIVE_RELOAD_ENABLED": "true",
 				}).

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -94,17 +94,20 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Executing build process",
-				fmt.Sprintf("    Running 'go build -o /layers/%s/targets/bin -buildmode pie -trimpath .'", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				MatchRegexp(fmt.Sprintf(`Running 'go build -o /layers/%s/targets/bin -buildmode ([^\s]+) -trimpath .'`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				fmt.Sprintf("  Generating SBOM for /layers/%s/targets/bin", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Writing SBOM in the following format(s):",
 				"    application/vnd.cyclonedx+json",
 				"    application/spdx+json",
 				"    application/vnd.syft+json",
-				"",
+			))
+			Expect(logs).To(ContainLines(
 				"  Assigning launch processes:",
 				fmt.Sprintf("    workspace (default): /layers/%s/targets/bin/workspace", strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
 			))

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -39,10 +39,8 @@ var settings struct {
 		Name string
 	}
 	Config struct {
-		GoDist       string `json:"go-dist"`
-		Watchexec    string `json:"watchexec"`
-		TinyBuilder  string `json:"tiny-builder"`
-		TinyRunImage string `json:"tiny-run-image"`
+		GoDist    string `json:"go-dist"`
+		Watchexec string `json:"watchexec"`
 	}
 }
 
@@ -99,16 +97,6 @@ func TestIntegration(t *testing.T) {
 	settings.Buildpacks.Watchexec.Offline, err = libpakBuildpackStore.Get.
 		WithOfflineDependencies().
 		Execute(settings.Config.Watchexec)
-	Expect(err).ToNot(HaveOccurred())
-
-	docker := occam.NewDocker()
-
-	t.Logf("Pulling image %s", settings.Config.TinyBuilder)
-	err = docker.Pull.Execute(settings.Config.TinyBuilder)
-	Expect(err).ToNot(HaveOccurred())
-
-	t.Logf("Pulling image %s", settings.Config.TinyRunImage)
-	err = docker.Pull.Execute(settings.Config.TinyRunImage)
 	Expect(err).ToNot(HaveOccurred())
 
 	builder, err = pack.Builder.Inspect.Execute()


### PR DESCRIPTION
## Summary

This PR adds support for the static stack out of the box. Specifically it sets: `CGO_ENABLED=0` environment variable and `-buildmode=default` build flag when it detects it is running on the static stack.

It does not set these if the user has already set a `-buildmode` flag (e.g. via `BP_GO_BUILD_FLAGS`) on the assumption that if the user is setting this they want their value to be preserved even if the build fails.

Additionally, this PR provides all the builders in the integration test, to ensure we are getting coverage on all supported stacks. It also cleans up some unused integration config.

## Use Cases

See https://github.com/paketo-buildpacks/go/issues/770

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
