### PR TITLE
feat: new BP_GO_WORKDIR variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ together with `BP_GO_TARGETS`.
 BP_GO_WORK_USE=./cmd/controller:./cmd/webhook
 ```
 
+### `BP_GO_WORKDIR`
+The `BP_GO_WORKDIR` specifies a subdirectory (relative to the app root) which
+will be used as build working directory. This is where the main go package lives.
+For most applications, it is the root directory and this variable is not needed;
+this is useful for monorepos or non-standard applications. The difference between
+`BP_GO_TARGETS` is that it specifies nested targets to build while this var
+changes the directory for building and builds from there.
+```shell
+BP_GO_WORKDIR=subdir/path/to/main
+```
+
 ### `BP_KEEP_FILES`
 The `BP_KEEP_FILES` variable allows to you to specity a path list of files
 (including file globs) that you would like to appear in the workspace of the

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -116,6 +116,7 @@ func TestIntegration(t *testing.T) {
 	suite("Rebuild", testRebuild)
 	suite("Targets", testTargets)
 	suite("Vendor", testVendor)
+	suite("WorkDir", testWorkDir)
 	suite("WorkUse", testWorkUse)
 	if builder.BuilderName != "paketobuildpacks/builder-jammy-buildpackless-static" {
 		suite("BuildFlags", testBuildFlags)

--- a/integration/testdata/workdir/README.md
+++ b/integration/testdata/workdir/README.md
@@ -1,0 +1,7 @@
+# Test project for BP_GO_WORKDIR
+
+This is a test application to verify that the BP_GO_WORKDIR environment variable
+works correctly.
+
+The Go application main is located in the `main/` subdirectory, and the
+buildpack should build from there when BP_GO_WORKDIR=main is set.

--- a/integration/testdata/workdir/main/go.mod
+++ b/integration/testdata/workdir/main/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.21

--- a/integration/testdata/workdir/main/main.go
+++ b/integration/testdata/workdir/main/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	fmt.Print("Hello from subdir!\n")
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello from subdir!")
+	})
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), nil))
+}

--- a/integration/workdir_test.go
+++ b/integration/workdir_test.go
@@ -1,0 +1,80 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testWorkDir(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack().WithVerbose().WithNoColor()
+		docker = occam.NewDocker()
+	})
+
+	context("when building an app with BP_GO_WORKDIR set", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds an application from a subdirectory", func() {
+			var err error
+			source, err = occam.Source(filepath.Join("testdata", "workdir"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var logs fmt.Stringer
+			image, logs, err = pack.Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.GoDist.Online,
+					settings.Buildpacks.GoBuild.Online,
+				).
+				WithEnv(map[string]string{
+					"BP_GO_WORKDIR": "main",
+				}).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String)
+
+			container, err = docker.Container.Run.
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				WithPublishAll().
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(Serve(ContainSubstring("Hello from subdir!")).OnPort(8080))
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Introduce new BP_GO_WORKDIR which can be set as a relative subpath of the whole working directory (--path) as a path where `go build` will be build from. Meaning effectively `cd into subdir && go build...` happens.

## Use Cases
Use case for mono repos and non-standard repos. The current implementation lacks option for main package to be different to the root of the project.

If a repo has non-standard dependency -- eg. when root is not the "main" package the build fails -- it **expects** the root to be the main package and derives its dependency tree in standard manner: from root to subdirs. If a repo uses non-standard go dependency tree it needs to build in the main package which means, in this case, from sub directory and this is what BP_GO_WORKDIR aims to enable; differentiate context directory (`--path` when pack building) and go workdir directory.

fixes https://github.com/paketo-buildpacks/go-build/issues/879

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
